### PR TITLE
Setup a/the local env (the same as the circleci env).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,12 @@ jobs:
     docker:
     - image: typelead/eta:latest
     environment:
-      JAVA_OPTS: -Xmx1G -Xms1G
+      ETA_JAVA_ARGS: -Xss512M -Xms1024M -Xmx1024M
     steps:
     - checkout
-    - run: ./scripts/init.sh
+    - run:
+        name: Init Bnechmarks
+        command: ./scripts/init.sh
     - run:
         name: Fast Benchmarks
         command: ./scripts/fast-benchmarks.sh
@@ -15,7 +17,7 @@ jobs:
     - run:
         name: Slow Benchmarks
         command: ./scripts/slow-benchmarks.sh
-        no_output_timeout: 1h
+        no_output_timeout: 2h
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The [Java Micobenchmarking Harness](http://openjdk.java.net/projects/code-tools/
 - JDK 1.7+
 - etlas
 
+Note: Please consider to run `. ./scripts/eta-set-env.sh` to make sure your local env is set to the same env that is used in `./.circle/config.yml`.
+
 ### Runner Installation
 
 First, get setup:

--- a/scripts/eta-set-env.sh
+++ b/scripts/eta-set-env.sh
@@ -1,0 +1,1 @@
+export ETA_JAVA_ARGS="-Xss512M -Xms1024M -Xmx1024M"


### PR DESCRIPTION
This PR ...

- introduces a script to set the local env so that it matches the circleci env
- also defines the stacksize (to make sure stack overflow problems become reproducable)
- increases the timeout (for no output) for the slow benchmarks to 2 hours