### PR TITLE
Run benchmarks in separate processes

### DIFF
--- a/scripts/disabled-benchmarks.sh
+++ b/scripts/disabled-benchmarks.sh
@@ -2,4 +2,7 @@
 
 BENCHMARKS=$(cat ./scripts/benchmarks | awk '{if ($1 == "disabled") print $2}')
 
-etlas run eta-bench -- $BENCHMARKS --way="-O2" --jmh="-wi 0 -i 1" --run --compiler="./scripts/eta.sh"
+for b in ${BENCHMARKS}
+do
+  etlas run eta-bench -- ${b} --way="-O2" --jmh="-wi 0 -i 1" --run --compiler="./scripts/eta.sh" || exit
+done

--- a/scripts/fast-benchmarks.sh
+++ b/scripts/fast-benchmarks.sh
@@ -2,4 +2,7 @@
 
 BENCHMARKS=$(cat ./scripts/benchmarks | awk '{if ($1 == "fast") print $2}')
 
-etlas run eta-bench -- $BENCHMARKS --way="-O2" --jmh="-wi 1 -i 5 -gc true -prof gc -f 3" --run --compiler="./scripts/eta.sh"
+for b in ${BENCHMARKS}
+do
+  etlas run eta-bench -- ${b} --way="-O2" --jmh="-wi 1 -i 5 -gc true -prof gc -f 3" --run --compiler="./scripts/eta.sh" || exit
+done

--- a/scripts/single-bench.sh
+++ b/scripts/single-bench.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-# ARGS: [test-name] [measurement iterations] [worker iterations]
+TEST_NAME=${1}
+MEASUREMENT_ITERATIONS=${2}
+WORKER_ITERATIONS=${3}
 
-# eta-bench "$1" --way="-O2" --jmh="-wi $3 -i $2 -bm ss -gc true -prof gc" --run
-etlas run eta-bench -- "$1" --way="-O2" --jmh="-wi $3 -i $2 -bm ss -gc true -prof gc" --run --compiler="./scripts/eta.sh"
+etlas run eta-bench -- "${TEST_NAME}" --way="-O2" --jmh="-wi ${WORKER_ITERATIONS} -i ${MEASUREMENT_ITERATIONS} -bm ss -gc true -prof gc" --run --compiler="./scripts/eta.sh"

--- a/scripts/slow-benchmarks.sh
+++ b/scripts/slow-benchmarks.sh
@@ -2,4 +2,7 @@
 
 BENCHMARKS=$(cat ./scripts/benchmarks | awk '{if ($1 == "slow") print $2}')
 
-etlas run eta-bench -- $BENCHMARKS --way="-O2" --jmh="-wi 0 -i 1 -bm ss" --run --compiler="./scripts/eta.sh"
+for b in ${BENCHMARKS}
+do
+  etlas run eta-bench -- ${b} --way="-O2" --jmh="-wi 0 -i 1 -bm ss" --run --compiler="./scripts/eta.sh" || exit
+done


### PR DESCRIPTION
Exec Summary: With this PR I want to increase the chance that tests will either always succeed or always fail (regardless of the env (local vs. ci) and regardless of the script (single vs. fast).

This PR is to improve the repeatability/reproducibility/stability of running the test(s) by running them in separate processes.

E.g. right now, I can real/bspt on my machine (with single-bench) and it succeeds, but when I run fast-bench it fails.

Also ... running fast-bench on my machine gives me only 2 tests that fail. Running fast-bench on circleci has much more tests (and different tests fail).

Note: Locally I run 0.8.6.3. On ci we run 0.8.6.4. Not sure, if/how that makes a difference.
