### PR TITLE
Fix spectral hartel wave4main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ jobs:
   build:
     docker:
     - image: typelead/eta:latest
-    environment:
-      ETA_JAVA_ARGS: -Xss512M -Xms2048M -Xmx2048M
     steps:
     - checkout
     - run:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ The [Java Micobenchmarking Harness](http://openjdk.java.net/projects/code-tools/
 - JDK 1.7+
 - etlas
 
-Note: Please consider to run `. ./scripts/eta-set-env.sh` to make sure your local env is set to the same env that is used in `./.circle/config.yml`.
-
 ### Runner Installation
 
 First, get setup:

--- a/scripts/eta-set-env.sh
+++ b/scripts/eta-set-env.sh
@@ -1,1 +1,0 @@
-export ETA_JAVA_ARGS="-Xss512M -Xms2048M -Xmx2048M"

--- a/scripts/run-local-benchmarks.sh
+++ b/scripts/run-local-benchmarks.sh
@@ -1,4 +1,4 @@
-. ./scripts/eta-set-env.sh
+#!/usr/bin/env sh
 
 MEASUREMENT_ITERATIONS=5
 WARMUP_ITERATIONS=1
@@ -63,7 +63,7 @@ WARMUP_ITERATIONS=1
 ./scripts/single-bench.sh spectral/hartel/transform ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
 ./scripts/single-bench.sh spectral/hartel/typecheck ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
 ./scripts/single-bench.sh spectral/hartel/wang ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
-#./scripts/single-bench.sh spectral/hartel/wave4main ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
+./scripts/single-bench.sh spectral/hartel/wave4main ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
 ./scripts/single-bench.sh spectral/integer ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
 ./scripts/single-bench.sh spectral/knights ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}
 ./scripts/single-bench.sh spectral/lambda ${MEASUREMENT_ITERATIONS} ${WARMUP_ITERATIONS}

--- a/spectral/hartel/wave4main/Makefile
+++ b/spectral/hartel/wave4main/Makefile
@@ -6,6 +6,7 @@ SRC_HC_OPTS += -cpp -XMagicHash
 FAST_OPTS = 4000
 NORM_OPTS = 4000
 SLOW_OPTS = 6000
-SRC_RUNTEST_OPTS = +RTS -K6m -RTS
+
+SRC_RUNTEST_OPTS = +RTS -K512m -RTS
 
 include $(TOP)/mk/target.mk


### PR DESCRIPTION
spectral/hartel/wave4main was failing with a stack overflow.

Turns out that this was a symptom of a bigger problem.

eta-bench is not running the benchmarks, but forks/starts a new JVM to run the benchmarks (see Build.hs).

Means all env vars (JAVA_OPTS, ETA_JAVA_ARGS, ...) are NOT used to configure the benchmarks. They are JUST used to configure eta-bench (which is meaningless, because eta-bench is just a runner and does not need a lot of stack/heap).

The stack/heap of benchmarks itself are configured through a piece of code that reads the RTS values from the Makefile and "translates" them into the right -Xss/-Xms/-Xmx values.

With this PR I am getting rid of all env vars (because having them might lead somebody to the conclusion that they have an effect) and configure the stack for wave4main through the makefile.