### PR TITLE
Reintroduce ETA_JAVA_ARGS (to limit the size of eta-bench).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   build:
     docker:
     - image: typelead/eta:0.8.6b4
+    env:
+    - ETA_JAVA_ARGS: -Xms1024M -Xmx1024M
     steps:
     - checkout
     - run:


### PR DESCRIPTION
For some tests eta-bench takes up so much/too much mem (and then there is not enough mem left over to run the actual benchmark (because the container is limited to 4GB)).